### PR TITLE
bump python version to 3.10

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,14 +2,14 @@ ARG BASE_IMAGE=nvidia/cuda:11.0-runtime-ubuntu20.04
 FROM ${BASE_IMAGE}
 ENV DEBIAN_FRONTEND="noninteractive"
 #----------------------------------------
-# Install latest python3.8 + pip3 and make them default
+# Install latest python3.10 + pip3 and make them default
 #----------------------------------------
 RUN apt update \
     && apt install -y --no-install-recommends software-properties-common \
     && add-apt-repository --yes ppa:deadsnakes/ppa \
     && apt update \
-    && apt install --no-install-recommends -y python3.8 python3.8-dev python3-pip \
-    && update-alternatives --install /usr/bin/python python /usr/bin/python3.8 1 \
+    && apt install --no-install-recommends -y python3.10 python3.10-dev python3-pip \
+    && update-alternatives --install /usr/bin/python python /usr/bin/python3.10 1 \
     && update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
 
 #----------------------------------------


### PR DESCRIPTION
Fixes #12. Bumps python version in Dockerfile to 3.10. On my fork I have ran [actions](https://github.com/unrndm/ml-toolbox/actions/runs/2951865223) and only push steps fail, all previous build steps are successful.